### PR TITLE
Configure GitHub Actions for Docker image build and push to Altacee registry

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -7,6 +7,7 @@ on:
 
 jobs:
   build:
+    runs-on: ubuntu-latest
     steps:
       # Checkout the repository
       - name: Checkout code

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,35 @@
+name: Build Docker Image
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  build:
+    steps:
+      # Checkout the repository
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      # Set up Docker Buildx (optional, for multi-platform builds)
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      # Log in to DockerHub (optional, if pushing to DockerHub)
+      - name: Log in to DockerHub
+        uses: docker/login-action@v2
+        with:
+          registry: registry.altacee.com
+          username: ${{ secrets.ACR_USERNAME }}
+          password: ${{ secrets.ACR_PASSWORD }}
+
+      # Build the Docker image
+      - name: Build Docker image
+        run: |
+          docker build -t registry.altacee.com/stratos/docs:latest .
+
+      # Push the Docker image (optional, if you want to push to DockerHub)
+      - name: Push Docker image
+        run: |
+          docker push registry.altacee.com/stratos/docs:latest


### PR DESCRIPTION
Set up GitHub Actions workflow to automatically build Docker images and push them to the Altacee container registry on every push to the main branch.